### PR TITLE
Feat elgamal

### DIFF
--- a/crypto-primitives/Cargo.toml
+++ b/crypto-primitives/Cargo.toml
@@ -55,3 +55,12 @@ ark-mnt6-298 = { version = "^0.2.0", default-features = false, features = [ "r1c
 
 [patch.crates-io]
 #ark-sponge = { git = "https://github.com/arkworks-rs/sponge" }
+
+[profile.dev]
+debug = true
+opt-level = 3
+
+[profile.release]
+debug = true
+opt-level = 3
+

--- a/crypto-primitives/Cargo.toml
+++ b/crypto-primitives/Cargo.toml
@@ -15,6 +15,8 @@ edition = "2018"
 ################################# Dependencies ################################
 
 [dependencies]
+hex = "0.4.3"
+
 ark-ff = { path = "../algebra/ff", version = "^0.2.0", default-features = false}
 ark-ec = { path = "../algebra/ec", version = "^0.2.0", default-features = false }
 ark-std = { path = "../utils", default-features = false }
@@ -37,7 +39,7 @@ tracing = { version = "0.1", default-features = false, features = [ "attributes"
 #ark-sponge = { version = "^0.3.0", default-features = false }
 
 [features]
-default = ["std"]
+default = ["r1cs"]
 std = [ "ark-ff/std", "ark-ec/std", "ark-std/std", "ark-relations/std" ]
 print-trace = [ "ark-std/print-trace" ]
 parallel = [ "std", "rayon", "ark-ec/parallel", "ark-std/parallel", "ark-ff/parallel" ]
@@ -45,7 +47,7 @@ r1cs = [ "ark-r1cs-std", "tracing", "ark-nonnative-field" ]
 
 [dev-dependencies]
 #ark-ed-on-bls12-381 = { version = "^0.2.0", default-features = false, features = [ "r1cs" ] }
-ark-ed-on-bls12-381 = { path = "../curves/ed_on_bls12_381/", default-features = false }
+ark-ed-on-bls12-381 = { path = "../curves/ed_on_bls12_381/", default-features = false, features = [ "r1cs" ] }
 
 ark-bls12-377 = { version = "^0.2.0", default-features = false, features = [ "curve", "r1cs" ] }
 ark-mnt4-298 = { version = "^0.2.0", default-features = false, features = [ "curve", "r1cs" ] }

--- a/crypto-primitives/src/crh/bowe_hopwood/constraints.rs
+++ b/crypto-primitives/src/crh/bowe_hopwood/constraints.rs
@@ -118,6 +118,7 @@ mod test {
     use ark_r1cs_std::{alloc::AllocVar, uint8::UInt8, R1CSVar};
     use ark_relations::r1cs::{ConstraintSystem, ConstraintSystemRef};
     use ark_std::test_rng;
+    use ark_std::vec::Vec;
 
     type TestCRH = CRH<EdwardsParameters, Window>;
     type TestCRHGadget = CRHGadget<EdwardsParameters, FqVar>;

--- a/crypto-primitives/src/crh/mimc/constraints.rs
+++ b/crypto-primitives/src/crh/mimc/constraints.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 //use core::ops::{MulAssign, AddAssign};
 use crate::crh::FixedLengthCRHGadget;
-//use crate::Vec; // what for?!
+use crate::Vec;
 use ark_ff::{Field, PrimeField};
 
 use ark_r1cs_std::R1CSVar;

--- a/crypto-primitives/src/encryption/constraints.rs
+++ b/crypto-primitives/src/encryption/constraints.rs
@@ -3,7 +3,7 @@ use crate::encryption::AsymmetricEncryptionScheme;
 use ark_r1cs_std::prelude::*;
 use ark_relations::r1cs::SynthesisError;
 use core::fmt::Debug;
-
+use ark_std::vec::Vec;
 use ark_ff::fields::Field;
 
 pub trait AsymmetricEncryptionGadget<C: AsymmetricEncryptionScheme, ConstraintF: Field> {
@@ -19,8 +19,8 @@ pub trait AsymmetricEncryptionGadget<C: AsymmetricEncryptionScheme, ConstraintF:
 
     fn encrypt(
         parameters: &Self::ParametersVar,
-        message: &Self::PlaintextVar,
+        message: Vec<Self::PlaintextVar>,
         randomness: &Self::RandomnessVar,
         public_key: &Self::PublicKeyVar,
-    ) -> Result<Self::OutputVar, SynthesisError>;
+    ) -> Result<Vec<Self::OutputVar>, SynthesisError>;
 }

--- a/crypto-primitives/src/encryption/elgamal/constraints.rs
+++ b/crypto-primitives/src/encryption/elgamal/constraints.rs
@@ -198,10 +198,11 @@ where
 
     fn encrypt(
         parameters: &Self::ParametersVar,
-        message: &Self::PlaintextVar,
+        message: Vec<Self::PlaintextVar>,
         randomness: &Self::RandomnessVar,
         public_key: &Self::PublicKeyVar,
-    ) -> Result<Self::OutputVar, SynthesisError> {
+    ) -> Result<Vec<Self::OutputVar>, SynthesisError> {
+        let msg_iter = message.iter();
         // flatten randomness to little-endian bit vector
         let randomness = randomness
             .0
@@ -209,23 +210,28 @@ where
             .flat_map(|b| b.to_bits_le().unwrap())
             .collect::<Vec<_>>();
 
-        // compute s = randomness*pk
-        let s = public_key.pk.clone().scalar_mul_le(randomness.iter())?;
 
-        // compute c1 = randomness*generator
-        let c1 = parameters
+        let mut cipher_vec = vec!();
+        for msg in msg_iter {
+            // compute s = randomness*pk
+            let s = public_key.pk.clone().scalar_mul_le(randomness.iter())?;
+
+            // compute c1 = randomness*generator
+            let c1 = parameters
             .generator
             .clone()
             .scalar_mul_le(randomness.iter())?;
 
-        // compute c2 = m + s
-        let c2 = message.plaintext.clone() + s;
+            // compute c2 = m + s
+            let c2 = msg.plaintext.clone() + s;
+            cipher_vec.push(Self::OutputVar {
+                c1,
+                c2,
+                _curve: PhantomData,
+            })
+        }
 
-        Ok(Self::OutputVar {
-            c1,
-            c2,
-            _curve: PhantomData,
-        })
+        Ok(cipher_vec)
     }
 }
 
@@ -233,11 +239,12 @@ where
 mod test {
     use crate::encryption::constraints::AsymmetricEncryptionGadget;
     use ark_ec::{AffineCurve, ProjectiveCurve};
-    use ark_std::{test_rng, UniformRand};
+    use ark_std::{test_rng, UniformRand, vec::Vec};
 
     use ark_ed_on_bls12_381::{constraints::EdwardsVar, EdwardsProjective as JubJub, Fq};
 
     use crate::encryption::elgamal::{constraints::ElGamalEncGadget, ElGamal, Randomness};
+    use crate::encryption::sub_strings;
     use crate::encryption::AsymmetricEncryptionScheme;
     use ark_r1cs_std::prelude::*;
     use ark_relations::r1cs::ConstraintSystem;
@@ -253,13 +260,23 @@ mod test {
         let parameters = MyEnc::setup(rng).unwrap();
         let (pk, _) = MyEnc::keygen(&parameters, rng).unwrap();
 
-        let mut bytes = hex::decode("01234567890123456789012345678901").unwrap();
-        bytes.reverse();
-        let msg_affine = <JubJub as ProjectiveCurve>::Affine::from_random_bytes(&bytes).unwrap();
-        let msg = msg_affine.mul_by_cofactor();
+        let plain_text = "012345678901234567890123456789012345678901";
+        
+        let msg_vec = sub_strings(plain_text, 32);
+        let mut msg_affine_vec : Vec<<JubJub as ProjectiveCurve>::Affine> = vec!();
+        let msg_iter = msg_vec.iter();
+
+        for msg in msg_iter {
+            let mut bytes = hex::decode(*msg).unwrap();
+            bytes.reverse();
+            let msg_affine = <JubJub as ProjectiveCurve>::Affine::from_random_bytes(&bytes).unwrap();
+            let msg_var = msg_affine.mul_by_cofactor();
+            msg_affine_vec.push(msg_var);
+        }
+
 
         let randomness = Randomness::rand(rng);
-        let primitive_result = MyEnc::encrypt(&parameters, &pk, &msg, &randomness).unwrap();
+        let primitive_result_vec = MyEnc::encrypt(&parameters, &pk, msg_affine_vec.clone(), &randomness).unwrap();
 
         // construct constraint system
         let cs = ConstraintSystem::<Fq>::new_ref();
@@ -275,12 +292,17 @@ mod test {
                 &parameters,
             )
             .unwrap();
-        let msg_var =
+        let mut msg_var_vec : Vec<<MyGadget as AsymmetricEncryptionGadget<MyEnc, Fq>>::PlaintextVar> = vec!();
+        let msg_affine_iter = msg_affine_vec.iter();
+        for msg_affine in msg_affine_iter {
+            let msg_var =
             <MyGadget as AsymmetricEncryptionGadget<MyEnc, Fq>>::PlaintextVar::new_witness(
                 ark_relations::ns!(cs, "gadget_message"),
-                || Ok(&msg),
+                || Ok(msg_affine),
             )
             .unwrap();
+            msg_var_vec.push(msg_var);
+        }
         let pk_var =
             <MyGadget as AsymmetricEncryptionGadget<MyEnc, Fq>>::PublicKeyVar::new_witness(
                 ark_relations::ns!(cs, "gadget_public_key"),
@@ -289,21 +311,30 @@ mod test {
             .unwrap();
 
         // use gadget
-        let result_var =
-            MyGadget::encrypt(&parameters_var, &msg_var, &randomness_var, &pk_var).unwrap();
+        let result_var_vec =
+            MyGadget::encrypt(&parameters_var, msg_var_vec, &randomness_var, &pk_var).unwrap();
 
         // check that result equals expected ciphertext in the constraint system
-        let expected_var =
-            <MyGadget as AsymmetricEncryptionGadget<MyEnc, Fq>>::OutputVar::new_input(
+        let mut expected_var_vec = vec!();
+        let primitive_iter = primitive_result_vec.iter();
+
+        for primitive_result in primitive_iter {
+            let expected_var = <MyGadget as AsymmetricEncryptionGadget<MyEnc, Fq>>::OutputVar::new_input(
                 ark_relations::ns!(cs, "gadget_expected"),
-                || Ok(&primitive_result),
+                || Ok(primitive_result),
             )
             .unwrap();
+            expected_var_vec.push(expected_var);
+        }
 
-        expected_var.enforce_equal(&result_var).unwrap(); 
+        assert_eq!(expected_var_vec.len(), result_var_vec.len());
 
-        assert_eq!(primitive_result.0.into_projective(), result_var.c1.value().unwrap());
-        assert_eq!(primitive_result.1.into_projective(), result_var.c2.value().unwrap());
+        for i in 0..expected_var_vec.len() {
+            expected_var_vec[i].enforce_equal(&result_var_vec[i]).unwrap(); 
+        }
+        
+        // assert_eq!(primitive_result.0.into_projective(), result_var.c1.value().unwrap());
+        // assert_eq!(primitive_result.1.into_projective(), result_var.c2.value().unwrap());
         assert!(cs.is_satisfied().unwrap());
     }
 }

--- a/crypto-primitives/src/encryption/elgamal/constraints.rs
+++ b/crypto-primitives/src/encryption/elgamal/constraints.rs
@@ -331,10 +331,10 @@ mod test {
 
         for i in 0..expected_var_vec.len() {
             expected_var_vec[i].enforce_equal(&result_var_vec[i]).unwrap(); 
+            assert_eq!(primitive_result_vec[i].0.into_projective(), result_var_vec[i].c1.value().unwrap());
+            assert_eq!(primitive_result_vec[i].1.into_projective(), result_var_vec[i].c2.value().unwrap());
         }
         
-        // assert_eq!(primitive_result.0.into_projective(), result_var.c1.value().unwrap());
-        // assert_eq!(primitive_result.1.into_projective(), result_var.c2.value().unwrap());
         assert!(cs.is_satisfied().unwrap());
     }
 }

--- a/crypto-primitives/src/encryption/elgamal/mod.rs
+++ b/crypto-primitives/src/encryption/elgamal/mod.rs
@@ -12,7 +12,8 @@ use ark_std::vec::Vec;
 pub struct ElGamal<C: ProjectiveCurve> {
     _group: PhantomData<C>,
 }
-
+#[derive(Derivative)]
+#[derivative(Clone(bound = "C: ProjectiveCurve"))]
 pub struct Parameters<C: ProjectiveCurve> {
     pub generator: C::Affine,
 }
@@ -21,6 +22,8 @@ pub type PublicKey<C> = <C as ProjectiveCurve>::Affine;
 
 pub struct SecretKey<C: ProjectiveCurve>(pub C::ScalarField);
 
+#[derive(Derivative)]
+#[derivative(Clone(bound = "C: ProjectiveCurve"))]
 pub struct Randomness<C: ProjectiveCurve>(pub C::ScalarField);
 
 impl<C: ProjectiveCurve> UniformRand for Randomness<C> {

--- a/crypto-primitives/src/encryption/mod.rs
+++ b/crypto-primitives/src/encryption/mod.rs
@@ -7,6 +7,7 @@ pub mod elgamal;
 
 use crate::Error;
 use ark_std::rand::Rng;
+use ark_std::vec::Vec;
 
 pub trait AsymmetricEncryptionScheme {
     type Parameters;
@@ -26,13 +27,29 @@ pub trait AsymmetricEncryptionScheme {
     fn encrypt(
         pp: &Self::Parameters,
         pk: &Self::PublicKey,
-        message: &Self::Plaintext,
+        message: Vec<Self::Plaintext>,
         r: &Self::Randomness,
-    ) -> Result<Self::Ciphertext, Error>;
+    ) -> Result<Vec<Self::Ciphertext>, Error>;
 
     fn decrypt(
         pp: &Self::Parameters,
         sk: &Self::SecretKey,
-        ciphertext: &Self::Ciphertext,
-    ) -> Result<Self::Plaintext, Error>;
+        ciphertext: Vec<Self::Ciphertext>,
+    ) -> Result<Vec<Self::Plaintext>, Error>;
+}
+
+pub fn sub_strings(string: &str, sub_len: usize) -> Vec<&str> {
+    let mut subs = Vec::with_capacity(string.len() / sub_len);
+    let mut iter = string.chars();
+    let mut pos = 0;
+
+    while pos < string.len() {
+        let mut len = 0;
+        for ch in iter.by_ref().take(sub_len) {
+            len += ch.len_utf8();
+        }
+        subs.push(&string[pos..pos + len]);
+        pos += len;
+    }
+    subs
 }

--- a/crypto-primitives/src/prf/blake2s/constraints.rs
+++ b/crypto-primitives/src/prf/blake2s/constraints.rs
@@ -393,6 +393,7 @@ impl<F: PrimeField> PRFGadget<Blake2s, F> for Blake2sGadget {
 mod test {
     use ark_ed_on_bls12_381::Fq as Fr;
     use ark_std::rand::Rng;
+    use ark_std::vec::Vec;
 
     use crate::prf::blake2s::{constraints::evaluate_blake2s, Blake2s as B2SPRF};
     use ark_relations::r1cs::ConstraintSystem;

--- a/mpc-snarks/Cargo.toml
+++ b/mpc-snarks/Cargo.toml
@@ -54,6 +54,8 @@ merlin = "3"
 sha2 = "0.9"
 blake2 = "0.9"
 
+hex = "0.4.3"
+
 [[bin]]
 name = "client"
 path = "src/client.rs"
@@ -62,5 +64,11 @@ path = "src/client.rs"
 name = "proof"
 path = "src/proof.rs"
 
+[profile.dev]
+debug = true
+opt-level = 3
+
 [profile.release]
 debug = true
+opt-level = 3
+

--- a/mpc-snarks/src/client.rs
+++ b/mpc-snarks/src/client.rs
@@ -194,10 +194,7 @@ impl Computation {
         let outputs: Vec<MFr> = match self {
             Computation::Groth16 => {
                 //groth::mpc_test_prove_and_verify::<
-                groth::mpc_test_prove_and_verify_on_poseidon::<
-                    ark_bls12_377::Bls12_377,
-                    mpc_algebra::AdditivePairingShare<ark_bls12_377::Bls12_377>,
-                >(1);
+                groth::mpc_test_prove_and_verify_on_elgamal(1);
                 vec![]
             }
             Computation::Marlin => {

--- a/mpc-snarks/src/elgamal.rs
+++ b/mpc-snarks/src/elgamal.rs
@@ -1,0 +1,95 @@
+use ark_crypto_primitives::encryption::{constraints::AsymmetricEncryptionGadget};
+use ark_std::{vec::Vec};
+use ark_ed_on_bls12_381::{constraints::EdwardsVar, EdwardsProjective as JubJub, Fq};
+
+use ark_crypto_primitives::encryption::elgamal::{constraints::ElGamalEncGadget, ElGamal, Parameters, Plaintext, Ciphertext, Randomness, PublicKey};
+use ark_r1cs_std::prelude::*;
+use ark_relations::r1cs::{SynthesisError, ConstraintSystemRef, ConstraintSynthesizer};
+
+
+#[derive(Clone)]
+pub struct ElGamalCircuit {
+    pub parameters: Parameters<JubJub>,
+    pub input: Vec<Plaintext<JubJub>>,
+    pub output: Vec<Ciphertext<JubJub>>,
+    pub randomness: Randomness<JubJub>,
+    pub public_key: PublicKey<JubJub>
+}
+
+impl ConstraintSynthesizer<Fq> for ElGamalCircuit {
+    fn generate_constraints(self, cs: ConstraintSystemRef<Fq>) -> Result<(), SynthesisError> {
+
+        elgamal_circuit_helper(cs, self.parameters, self.input, self.output, self.randomness, self.public_key)?;
+
+        Ok(())
+    }
+}
+
+fn elgamal_circuit_helper(
+    cs: ConstraintSystemRef<Fq>,
+    parameters: Parameters<JubJub>,
+    input:  Vec<Plaintext<JubJub>>,
+    output:  Vec<Ciphertext<JubJub>>,
+    randomness: Randomness<JubJub>,
+    public_key: PublicKey<JubJub>,
+    ) -> Result<(), SynthesisError> 
+{
+
+    type PlainEnc = ElGamal<JubJub>;
+    type EncGadget = ElGamalEncGadget<JubJub, EdwardsVar>;
+
+    // construct constraint system
+    let randomness_var =
+        <EncGadget as AsymmetricEncryptionGadget<PlainEnc, Fq>>::RandomnessVar::new_witness(
+            ark_relations::ns!(cs, "gadget_randomness"),
+            || Ok(&randomness),
+        )
+        .unwrap();
+    let parameters_var =
+        <EncGadget as AsymmetricEncryptionGadget<PlainEnc, Fq>>::ParametersVar::new_constant(
+            ark_relations::ns!(cs, "gadget_parameters"),
+            &parameters,
+        )
+        .unwrap();
+    let mut msg_var_vec : Vec<<EncGadget as AsymmetricEncryptionGadget<PlainEnc, Fq>>::PlaintextVar> = vec!();
+    let input_iter = input.iter();
+    for plain_affine in input_iter {
+        let msg_var =
+        <EncGadget as AsymmetricEncryptionGadget<PlainEnc, Fq>>::PlaintextVar::new_witness(
+            ark_relations::ns!(cs, "gadget_message"),
+            || Ok(plain_affine),
+        )
+        .unwrap();
+        msg_var_vec.push(msg_var);
+    }
+    let pk_var =
+        <EncGadget as AsymmetricEncryptionGadget<PlainEnc, Fq>>::PublicKeyVar::new_witness(
+            ark_relations::ns!(cs, "gadget_public_key"),
+            || Ok(&public_key),
+        )
+        .unwrap();
+
+    // use gadget
+    let result_var_vec =
+        EncGadget::encrypt(&parameters_var, msg_var_vec, &randomness_var, &pk_var).unwrap();
+
+    // check that result equals expected ciphertext in the constraint system
+    let mut expected_var_vec = vec!();
+    let primitive_output_iter = output.iter();
+
+    for primitive_result in primitive_output_iter {
+        let expected_var = <EncGadget as AsymmetricEncryptionGadget<PlainEnc, Fq>>::OutputVar::new_input(
+            ark_relations::ns!(cs, "gadget_expected"),
+            || Ok(primitive_result),
+        )
+        .unwrap();
+        expected_var_vec.push(expected_var);
+    }
+
+    for i in 0..expected_var_vec.len() {
+        expected_var_vec[i].enforce_equal(&result_var_vec[i]).unwrap(); 
+    }
+
+
+    Ok(())
+}

--- a/mpc-snarks/src/groth.rs
+++ b/mpc-snarks/src/groth.rs
@@ -182,9 +182,18 @@ pub fn mpc_test_prove_and_verify_on_elgamal( n_iters: usize) {
 
     // verifying
     let pvk = prepare_verifying_key(&zk_param.vk);
-    // let res = verify_proof(&pvk, &proof, &primitive_result_vec).unwrap();
+    let mut public_inputs = vec!();
+    for affine in primitive_result_vec {
+        public_inputs.push(affine.0.x);
+        public_inputs.push(affine.0.y);
+        public_inputs.push(affine.1.x);
+        public_inputs.push(affine.1.y);
+    }
 
-    // assert!(res);
+    let res = verify_proof(&pvk, &proof, &public_inputs).unwrap();
+    println!("verify: {:?}", res);
+
+    assert!(res);
     
     }
 

--- a/mpc-snarks/src/lib.rs
+++ b/mpc-snarks/src/lib.rs
@@ -1,6 +1,8 @@
 mod poseidon;
 mod mimc;
 
+pub mod elgamal;
+
 mod silly;
 
 #[cfg(test)]

--- a/snark/Cargo.toml
+++ b/snark/Cargo.toml
@@ -20,7 +20,7 @@ incremental = true
 debug-assertions = false
 
 [profile.dev]
-opt-level = 0
+opt-level = 3
 panic = 'abort'
 
 [profile.test]


### PR DESCRIPTION
### Summary
elgamal encryption을 mpc-snarks에서 돌릴 수 있도록 구현하였습니다.

### Checklist
- [x] elgamal gadget 수정
- [x] elgamal circuit 추가
- [x] `mpc-snark/groth.rs`에서 elgamal circuit으로 proof 생성
- [x] public input type 이슈 해결 후 verify 확인